### PR TITLE
fix: Update JarLauncher class path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN mkdir -pv ./.cockroach-key
 
 EXPOSE 9999
 
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
Closes #40 

Build/run output:
```
$ git log -n 1 --oneline
c5e6322 (HEAD -> master, origin/master, origin/HEAD) fix: Update JarLauncher class path

$ docker build -t timveil/cockroachdb-dynamic-certs:latest . && docker run -it timveil/cockroachdb-dynamic-certs:latest
.
.
.

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.2.0)

2023-11-27T17:38:53.440Z  INFO 1 --- [           main] io.crdb.docker.DynamicCertsApplication   : Starting DynamicCertsApplication v21.0.0-SNAPSHOT using Java 19.0.2 with PID 1 (/BOOT-INF/classes started by root in /)
```